### PR TITLE
Fix native ethernet

### DIFF
--- a/platform_code/arduino/native_ethernet/micro_ros_transport.cpp
+++ b/platform_code/arduino/native_ethernet/micro_ros_transport.cpp
@@ -2,7 +2,7 @@
 
 #include <micro_ros_platformio.h>
 
-#include <EthernetUdp.h>
+#include <NativeEthernetUdp.h>
 
 #include <uxr/client/util/time.h>
 #include <uxr/client/profile/transport/custom/custom_transport.h>

--- a/platform_code/arduino/native_ethernet/micro_ros_transport.h
+++ b/platform_code/arduino/native_ethernet/micro_ros_transport.h
@@ -17,7 +17,7 @@ static inline void set_microros_native_ethernet_transports(byte mac[], IPAddress
 
 	rmw_uros_set_custom_transport(
 		false,
-		NULL,
+		&locator,
 		platformio_transport_open,
 		platformio_transport_close,
 		platformio_transport_write,

--- a/platform_code/arduino/native_ethernet/micro_ros_transport.h
+++ b/platform_code/arduino/native_ethernet/micro_ros_transport.h
@@ -1,4 +1,4 @@
-#include <Ethernet.h>
+#include <NativeEthernet.h>
 
 struct micro_ros_agent_locator {
 	IPAddress address;


### PR DESCRIPTION
The `board_microros_transport = native_ethernet` for the Teensy 4.1 doesn't work out of box. These two fixes are necessary.

My setup:

- PlatformIO Core, version 5.2.4
- ros2 Galactic
- Teensy 4.1
- Ethernet Bridge (no direct connection)
