### PR TITLE
micro_ros_platformio works on Raspberry Pi Pico

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            platform: [teensy41, teensy40, teensy36, teensy35, teensy31, due, zero, olimex_e407, esp32dev, nanorp2040connect, portenta_h7_m7, teensy41_eth, nanorp2040connect_wifi, portenta_h7_m7_wifi, esp32dev_wifi, portenta_h7_m7_galactic, portenta_h7_m7_foxy, portenta_h7_m7_rolling, teensy41_custom]
+            platform: [teensy41, teensy40, teensy36, teensy35, teensy31, due, zero, olimex_e407, esp32dev, nanorp2040connect, portenta_h7_m7, teensy41_eth, nanorp2040connect_wifi, portenta_h7_m7_wifi, esp32dev_wifi, portenta_h7_m7_galactic, portenta_h7_m7_foxy, portenta_h7_m7_rolling, teensy41_custom, pico]
 
         steps:
         - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -240,3 +240,8 @@ see the file [3rd-party-licenses.txt](3rd-party-licenses.txt).
     ```ini
     lib_ldf_mode = chain+
     ```
+- For `pico` board with `serial` transport, the library dependency finder shall be set to `chain+`:
+
+    ```ini
+    lib_ldf_mode = chain+
+    ```

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Supported boards are:
 | `olimex_e407`                                | `ststm32`     | `arduino`   | `serial`                         | `colcon.meta`            |
 | `esp32dev`                                   | `espressif32` | `arduino`   | `serial` <br/> `wifi`            | `colcon.meta`            |
 | `nanorp2040connect`                          | `raspberrypi` | `arduino`   | `serial` <br/> `wifi_nina`       | `colcon_verylowmem.meta` |
+| `pico`                                       | `raspberrypi` | `arduino`   | `serial`                         | `colcon.mata`|
 
 The community is encouraged to open pull request with custom use cases.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Supported boards are:
 | `olimex_e407`                                | `ststm32`     | `arduino`   | `serial`                         | `colcon.meta`            |
 | `esp32dev`                                   | `espressif32` | `arduino`   | `serial` <br/> `wifi`            | `colcon.meta`            |
 | `nanorp2040connect`                          | `raspberrypi` | `arduino`   | `serial` <br/> `wifi_nina`       | `colcon_verylowmem.meta` |
-| `pico`                                       | `raspberrypi` | `arduino`   | `serial`                         | `colcon.mata`|
+| `pico`                                       | `raspberrypi` | `arduino`   | `serial`                         | `colcon.meta`|
 
 The community is encouraged to open pull request with custom use cases.
 

--- a/ci/platformio.ini
+++ b/ci/platformio.ini
@@ -123,6 +123,7 @@ lib_deps =
 platform = raspberrypi
 board = pico
 framework = arduino
+lib_ldf_mode = chain+
 board_microros_transport = serial
 lib_deps =
     ../

--- a/ci/platformio.ini
+++ b/ci/platformio.ini
@@ -118,6 +118,14 @@ lib_ldf_mode = chain+
 board_microros_transport = serial
 lib_deps =
     ../
+    
+[env:pico]
+platform = raspberrypi
+board = pico
+framework = arduino
+board_microros_transport = serial
+lib_deps =
+    ../
 
 ; Ethernet platforms
 

--- a/extra_script.py
+++ b/extra_script.py
@@ -20,7 +20,9 @@ boards_metas = {
     "esp32dev" : "colcon.meta",
     "olimex_e407" :  "colcon.meta",
     "due" : "colcon_verylowmem.meta",
-    "zero" : "colcon_verylowmem.meta"
+    "zero" : "colcon_verylowmem.meta",
+    "pico": "colcon.meta"
+
 }
 
 project_options = env.GetProjectConfig().items(env=env["PIOENV"], as_dict=True)
@@ -100,7 +102,7 @@ def build_microros(*args, **kwargs):
     #######################################################
 
     # Add library
-    if (board == "portenta_h7_m7" or board == "nanorp2040connect"):
+    if (board == "portenta_h7_m7" or board == "nanorp2040connect" or board == "pico"):
         # Workaround for including the library in the linker group
         #   This solves a problem with duplicated symbols in Galactic
         global_env["_LIBFLAGS"] = "-Wl,--start-group " + global_env["_LIBFLAGS"] + " -l{} -Wl,--end-group".format(builder.library_name)


### PR DESCRIPTION
Presented example works properly on RPi Pico

platformio.ini:
``` bash
[env:pico]
platform = raspberrypi
board = pico
framework = arduino
board_microros_transport = serial
lib_deps =
    https://github.com/delihus/micro_ros_platformio
```

logs
``` bash
[1658131559.396250] debug    | DataWriter.cpp     | write                    | [** <<DDS>> **]        | client_key: 0x00000000, len: 4, data: 
0000: 74 00 00 00
[1658131559.396320] debug    | SerialAgentLinux.cpp | send_message             | [** <<SER>> **]        | client_key: 0x653160D0, len: 13, data: 
0000: 81 00 00 00 0A 01 05 00 79 00 00 00 80
[1658131560.397140] debug    | SerialAgentLinux.cpp | recv_message             | [==>> SER <<==]        | client_key: 0x653160D0, len: 16, data: 
0000: 81 80 79 00 07 01 08 00 00 83 00 05 75 00 00 00
[1658131560.397504] debug    | DataWriter.cpp     | write                    | [** <<DDS>> **]        | client_key: 0x00000000, len: 4, data: 
0000: 75 00 00 00
[1658131560.397600] debug    | SerialAgentLinux.cpp | send_message             | [** <<SER>> **]        | client_key: 0x653160D0, len: 13, data: 
0000: 81 00 00 00 0A 01 05 00 7A 00 00 00 80
[1658131561.398154] debug    | SerialAgentLinux.cpp | recv_message             | [==>> SER <<==]        | client_key: 0x653160D0, len: 16, data: 
0000: 81 80 7A 00 07 01 08 00 00 84 00 05 76 00 00 00
[1658131561.398494] debug    | DataWriter.cpp     | write                    | [** <<DDS>> **]        | client_key: 0x00000000, len: 4, data: 
0000: 76 00 00 00
[1658131561.398629] debug    | SerialAgentLinux.cpp | send_message             | [** <<SER>> **]        | client_key: 0x653160D0, len: 13, data: 
0000: 81 00 00 00 0A 01 05 00 7B 00 00 00 80
[1658131562.399237] debug    | SerialAgentLinux.cpp | recv_message             | [==>> SER <<==]        | client_key: 0x653160D0, len: 16, data: 
0000: 81 80 7B 00 07 01 08 00 00 85 00 05 77 00 00 00
[1658131562.399634] debug    | DataWriter.cpp     | write                    | [** <<DDS>> **]        | client_key: 0x00000000, len: 4, data: 
0000: 77 00 00 00
[1658131562.399842] debug    | SerialAgentLinux.cpp | send_message             | [** <<SER>> **]        | client_key: 0x653160D0, len: 13, data: 
0000: 81 00 00 00 0A 01 05 00 7C 00 00 00 80
```