### PR TITLE
Fix generation of idedata

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -112,6 +112,7 @@ def build_microros(*args, **kwargs):
     # Add library path
     global_env.Append(LIBPATH=[builder.library_path])
 
+def update_env():
     # Add required defines
     global_env.Append(CPPDEFINES=[("CLOCK_MONOTONIC", 1)])
 
@@ -150,3 +151,5 @@ from SCons.Script import COMMAND_LINE_TARGETS
 # Do not build library on clean_microros target or when IDE fetches C/C++ project metadata
 if set(["clean_microros", "_idedata", "idedata"]).isdisjoint(set(COMMAND_LINE_TARGETS)):
     build_microros()
+
+update_env()


### PR DESCRIPTION
Fixes #32 .
I wrote this PR only to demonstrate the problem, not to provide the best solution.
AFAIK, running `pio init --ide <ide name>` runs the `idedata` target to generate `idedata.json` file which contains information about include paths, defines etc. which is used to generate IDE-specific configuration files. 
Currently the `extra_script.py` completely ignores the `idedata` target. This was done to avoid building the library when IDE fetches project metadata.
I think the script should instead update some of the environments (probably the `global_env` and `projenv`) regardless of the target name. 