### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This allows the user to customize the library memory resources or activate optio
 - Documentation on available parameters can be found [here](https://micro.ros.org/docs/tutorials/advanced/microxrcedds_rmw_configuration) and [here]([microxrcedds_rmw_configuration](https://micro-xrce-dds.docs.eprosima.com/en/latest/client.html)).
 - Default configurations can be found on the [metas](./metas) folder.
 
-  *Note: the [common.meta](./metas/common.meta) file makes general adjustments to the library and shall not be modified by the user.*
+  *Note: the [common.meta](./metas/common.meta) file makes general adjustments to the library and shall not be modified by the user. In addition, do not use tabs (/t) when creating the custom meta file as it result in the meta file being ignored.  Use only spaces.*
 
 ## Extend library targets
 This library can be easily adapted to different boards, transports or RTOS, to achieve this the user shall provide:


### PR DESCRIPTION
#### Steps to reproduce the issue
Use a tab in your custom meta file and force micro-ros to be rebuilt and the file will be ignored because of the tab.

#### Additional information
So, I spent about 6 hours trying to get a custom meta file to work.  My first challenge was to get micro-ros library to rebuild (pio run --target clean does not force the rebuild).  I ended up just deleting the library directory and that forced it to download everything (is there a better, simpler way?) Rebuilding is a rather long process so I don't really pay attention to it, but the third time I forced it to rebuild I did pay attention and I saw an error appear that said that the presence of a tab at the beginning of the line I had added to my meta file was invalid and therefore the file will be ignored. Now, this is likely the "expected outcome" and I don't even think this is necessarily a platformio issue.  However, I'm hoping that by submitting this PR someone will save themselves the same headache as I have had with using the custom meta file.