### PR TITLE
Update library_builder.py

### DIFF
--- a/microros_utils/library_builder.py
+++ b/microros_utils/library_builder.py
@@ -120,7 +120,6 @@ class Build:
 
                 print('\t - Downloaded {}{}'.format(package.name, " (ignored)" if package.ignored else ""))
 
-        self.download_extra_packages()
 
     def download_extra_packages(self):
         if not os.path.exists(self.packages_folder):


### PR DESCRIPTION
In the end of function ‘download_mcu_environment’， line139，download_extra_packages once。 but in line 75， download_extra_packages again。
which will cause error [fatal: destination path '/home/xxx/Desktop/arduino/hello_microros/.pio/libdeps/featheresp32/micro_ros_platformio/build/mcu/src/control_msgs' already exists and is not an empty directory.]