### PR TITLE
Check for custom target presence before registering it

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -61,7 +61,8 @@ def clean_microros_callback(*args, **kwargs):
     print("micro-ROS library cleaned!")
     os._exit(0)
 
-global_env.AddCustomTarget("clean_microros", None, clean_microros_callback, title="Clean Micro-ROS", description="Clean Micro-ROS build environment")
+if "clean_microros" not in global_env.get("__PIO_TARGETS", {}):
+   global_env.AddCustomTarget("clean_microros", None, clean_microros_callback, title="Clean Micro-ROS", description="Clean Micro-ROS build environment")
 
 def build_microros(*args, **kwargs):
     ##############################


### PR DESCRIPTION
This change updates the `extra_script.py` script to check for presence of the `clean_microros` PlatformIO target before adding it. The error trace and the fix are discussed in detail at https://community.platformio.org/t/build-error-platformio-init/35219.