### PR TITLE
timer: proper way to check POSIX timers support

### DIFF
--- a/platform_code/arduino/clock_gettime.cpp
+++ b/platform_code/arduino/clock_gettime.cpp
@@ -3,7 +3,7 @@
 #include <sys/time.h>
 #define micro_rollover_useconds 4294967295
 
-#ifndef WITH_POSIX
+#ifndef _POSIX_TIMERS
 
 extern "C" int clock_gettime(clockid_t unused, struct timespec *tp)
 {
@@ -22,4 +22,4 @@ extern "C" int clock_gettime(clockid_t unused, struct timespec *tp)
     return 0;
 }
 
-#endif  // ifndef WITH_POSIX
+#endif  // ifndef _POSIX_TIMERS


### PR DESCRIPTION
The _POSIX_TIMERS macros can be used to determine the degree of a host's support for the posix timers API.

The POSIX definition (2018 edition) says that:

_POSIX_TIMERS

The implementation supports timers. This symbol shall always be set to the value 200809L.

It's defined in the <unistd.h> header.

Tested on esp32, pico and teensy4.