### PR TITLE
Update extra_script.py and library_builder.py to speed up the build

### DIFF
--- a/extra_script.py
+++ b/extra_script.py
@@ -64,6 +64,19 @@ def clean_microros_callback(*args, **kwargs):
 if "clean_microros" not in global_env.get("__PIO_TARGETS", {}):
    global_env.AddCustomTarget("clean_microros", None, clean_microros_callback, title="Clean Micro-ROS", description="Clean Micro-ROS build environment")
 
+def clean_libmicroros_callback(*args, **kwargs):
+    library_path = main_path + '/libmicroros'
+
+    # Delete libmicroros folder
+    shutil.rmtree(library_path, ignore_errors=True)
+
+    print("libmicroros cleaned")
+    os._exit(0)
+
+if "clean_libmicroros" not in global_env.get("__PIO_TARGETS", {}):
+   global_env.AddCustomTarget("clean_libmicroros", None, clean_libmicroros_callback, title="Clean libmicroros", description="Clean libmicroros")
+
+
 def build_microros(*args, **kwargs):
     ##############################
     #### Install dependencies ####
@@ -154,7 +167,7 @@ def update_env():
 from SCons.Script import COMMAND_LINE_TARGETS
 
 # Do not build library on clean_microros target or when IDE fetches C/C++ project metadata
-if set(["clean_microros", "_idedata", "idedata"]).isdisjoint(set(COMMAND_LINE_TARGETS)):
+if set(["clean_microros", "clean_libmicroros", "_idedata", "idedata"]).isdisjoint(set(COMMAND_LINE_TARGETS)):
     build_microros()
 
 update_env()

--- a/microros_utils/library_builder.py
+++ b/microros_utils/library_builder.py
@@ -66,9 +66,6 @@ class Build:
         self.build_mcu_environment(meta, toolchain, user_meta)
         self.package_mcu_library()
 
-        # Delete build folders
-        shutil.rmtree(self.build_folder, ignore_errors=True)
-
     def ignore_package(self, name):
         for p in self.mcu_packages:
             if p.name == name:
@@ -90,8 +87,7 @@ class Build:
         self.env = os.environ.copy()
 
     def download_dev_environment(self):
-        shutil.rmtree(self.dev_src_folder, ignore_errors=True)
-        os.makedirs(self.dev_src_folder)
+        os.makedirs(self.dev_src_folder, exist_ok=True)
         print("Downloading micro-ROS dev dependencies")
         for repo in Sources.dev_environments[self.distro]:
             repo.clone(self.dev_src_folder)
@@ -108,8 +104,7 @@ class Build:
             sys.exit(1)
 
     def download_mcu_environment(self):
-        shutil.rmtree(self.mcu_src_folder, ignore_errors=True)
-        os.makedirs(self.mcu_src_folder)
+        os.makedirs(self.mcu_src_folder, exist_ok=True)
         print("Downloading micro-ROS library")
         for repo in Sources.mcu_environments[self.distro]:
             repo.clone(self.mcu_src_folder)

--- a/microros_utils/repositories.py
+++ b/microros_utils/repositories.py
@@ -27,6 +27,14 @@ class Repository:
     def clone(self, folder):
         self.path = folder + "/" + self.name
         # TODO(pablogs) ensure that git is installed
+        if os.path.exists(self.path):
+            command = f"cd {self.path} && git pull {self.url} {self.branch}"
+            result = run_cmd(command)
+            if 0 != result.returncode:
+                print(f"{self.name} pull failed: \n{result.stderr.decode('utf-8')}")
+                sys.exit(1)
+            return
+
         command = "git clone -b {} {} {}".format(self.branch, self.url, self.path)
         result = run_cmd(command)
 


### PR DESCRIPTION
Until now, you had to follow these steps to rebuild a library:
1. `platformio run --target clean_microros` : Delete all repositories of libraries.
2. `platformio run` : **Clone** all repositories of libraries and Build

It's very slow because it clone all repositories every time. So I changed it to use not clone but pull.
1. `platformio run --target clean_libmicroros` : Delete only libmicroros folder.
2. `platformio run` : **Pull** all repositories of libraries and Build