### PR TITLE
clock_gettime: check posix timer support

### DIFF
--- a/platform_code/arduino/clock_gettime.cpp
+++ b/platform_code/arduino/clock_gettime.cpp
@@ -3,7 +3,7 @@
 #include <sys/time.h>
 #define micro_rollover_useconds 4294967295
 
-#ifndef _POSIX_TIMERS
+#if !defined(_POSIX_TIMERS) || !_POSIX_TIMERS
 
 extern "C" int clock_gettime(clockid_t unused, struct timespec *tp)
 {


### PR DESCRIPTION
The recent changes in arduino pico breaks the check. Fix it by checking the _POSIX_TIMERS not defined or zero.

Issue #153 Build failing for humble in vscode - clock_gettime missing