### PR TITLE
pico: add user meta to disable rcutils atomic ops

### DIFF
--- a/ci/atomic.meta
+++ b/ci/atomic.meta
@@ -1,0 +1,9 @@
+{
+    "names": {
+        "rcutils": {
+            "cmake-args": [
+                "-DRCUTILS_NO_64_ATOMIC=OFF"
+            ]
+        }
+    }
+}

--- a/ci/platformio.ini
+++ b/ci/platformio.ini
@@ -135,6 +135,7 @@ board = pico
 framework = arduino
 lib_ldf_mode = chain+
 board_microros_transport = serial
+board_microros_user_meta = atomic.meta
 lib_deps =
     ../
 


### PR DESCRIPTION
The micro-ROS common.meta defines "-DRCUTILS_NO_64_ATOMIC=ON", which enables atomic ops functions in micro-ros/rcutils. But pico-sdk has build-in atomic ops, so they conflict and might result in link errors with newer toolchains.

An user.meta is added to disable rcutils atomic ops.