### PR TITLE
platform/core update for pico pico2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ on:
 jobs:
 
     micro_ros_platformio:
-        runs-on: ubuntu-22.04
-        container: ubuntu:22.04
+        runs-on: ubuntu-24.04
+        container: ubuntu:24.04
 
         strategy:
           fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
           fail-fast: false
           matrix:
-            platform: [teensy41, teensy40, teensy36, teensy35, teensy31, due, zero, olimex_e407, esp32dev, nanorp2040connect, portenta_h7_m7, teensy41_eth, nanorp2040connect_wifi, portenta_h7_m7_wifi, esp32dev_wifi, esp32dev_ethernet, portenta_h7_m7_humble, portenta_h7_m7_jazzy, portenta_h7_m7_kilted, portenta_h7_m7_rolling, teensy41_custom, pico]
+            platform: [teensy41, teensy40, teensy36, teensy35, teensy31, due, zero, olimex_e407, esp32dev, nanorp2040connect, portenta_h7_m7, teensy41_eth, nanorp2040connect_wifi, portenta_h7_m7_wifi, esp32dev_wifi, esp32dev_ethernet, portenta_h7_m7_humble, portenta_h7_m7_jazzy, portenta_h7_m7_kilted, portenta_h7_m7_rolling, teensy41_custom, pico, pico2]
 
         steps:
         - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Supported boards are:
 | `olimex_e407`                                | `ststm32`     | `arduino`   | `serial`                                 | `colcon.meta`            |
 | `esp32dev`                                   | `espressif32` | `arduino`   | `serial` <br/> `wifi` <br/> `ethernet`*   | `colcon.meta`            |
 | `nanorp2040connect`                          | `raspberrypi` | `arduino`   | `serial` <br/> `wifi_nina`               | `colcon_verylowmem.meta` |
-| `pico`                                       | `raspberrypi` | `arduino`   | `serial`                                 | `colcon.meta`            |
+| `pico`  <br/> `pico2`                        | `raspberrypi` | `arduino`   | `serial`                                 | `colcon.meta`            |
 
 \* Community contributed
 
@@ -70,6 +70,8 @@ brew install binutils
 
 The library can be included as a regular git library dependence on your `platform.ini` file:
 
+You may find a sample ini file at `ci/platformio.ini`.
+
 ```ini
 ...
 lib_deps =
@@ -98,7 +100,6 @@ A explanation for adding custom targets is also present
 ### ROS 2 distribution
 The target ROS 2 distribution can be configured with the `board_microros_distro = <distribution>`, supported values are:
   - `humble`
-  - `iron`
   - `jazzy` *(default value)*
   - `kilted`
   - `rolling`
@@ -236,6 +237,7 @@ A simple publisher project using serial transport is available on the [examples]
 
 - More micro-ROS usage examples are available on [micro-ROS-demos/rclc](https://github.com/micro-ROS/micro-ROS-demos/tree/jazzy/rclc).
 - For a complete micro-ROS tutorial, check [Programming with rcl and rclc](https://micro.ros.org/docs/tutorials/programming_rcl_rclc/overview/) documentation.
+- Community contributed tutorials for beginners with [examples ported from micro_ros_arduino](https://github.com/hippo5329/micro_ros_arduino_examples_platformio/wiki) and [examples ported from micro-ROS-demos](https://github.com/hippo5329/micro-ROS-demos-platformio/wiki).
 
 ## Purpose of the Project
 
@@ -252,23 +254,3 @@ This repository is open-sourced under the Apache-2.0 license. See the [LICENSE](
 
 For a list of other open-source components included in this repository,
 see the file [3rd-party-licenses.txt](3rd-party-licenses.txt).
-
-## Known Issues/Limitations
-
-- For `wifi_nina` transport, the following versioning shall be used:
-
-    ```ini
-    lib_deps =
-      arduino-libraries/WiFiNINA@^1.8.13
-    ```
-
-- For `nanorp2040connect` board with `serial` transport, the library dependency finder shall be set to `chain+`:
-
-    ```ini
-    lib_ldf_mode = chain+
-    ```
-- For `pico` board with `serial` transport, the library dependency finder shall be set to `chain+`:
-
-    ```ini
-    lib_ldf_mode = chain+
-    ```

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ A explanation for adding custom targets is also present
 ### ROS 2 distribution
 The target ROS 2 distribution can be configured with the `board_microros_distro = <distribution>`, supported values are:
   - `humble`
-  - `jazzy` *(default value)*
-  - `kilted`
+  - `jazzy`
+  - `kilted` *(default value)*
   - `rolling`
 
 ### Transport configuration

--- a/ci/atomic.meta
+++ b/ci/atomic.meta
@@ -1,0 +1,9 @@
+{
+    "names": {
+        "rcutils": {
+            "cmake-args": [
+                "-DRCUTILS_NO_64_ATOMIC=OFF"
+            ]
+        }
+    }
+}

--- a/ci/platformio.ini
+++ b/ci/platformio.ini
@@ -121,20 +121,32 @@ lib_deps =
     ../
 
 [env:nanorp2040connect]
-platform = raspberrypi
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = nanorp2040connect
+board_build.core = earlephilhower
 framework = arduino
-lib_ldf_mode = chain+
 board_microros_transport = serial
+board_microros_user_meta = atomic.meta
 lib_deps =
     ../
-    
+
 [env:pico]
-platform = raspberrypi
-board = pico
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico
+board_build.core = earlephilhower
 framework = arduino
-lib_ldf_mode = chain+
 board_microros_transport = serial
+board_microros_user_meta = atomic.meta
+lib_deps =
+    ../
+
+[env:pico2]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico2
+board_build.core = earlephilhower
+framework = arduino
+board_microros_transport = serial
+board_microros_user_meta = atomic.meta
 lib_deps =
     ../
 
@@ -175,12 +187,14 @@ lib_deps =
     ../
 
 [env:nanorp2040connect_wifi]
-platform = raspberrypi
+ platform = https://github.com/maxgerhardt/platform-raspberrypi.git
 board = nanorp2040connect
+board_build.core = earlephilhower
 framework = arduino
 board_microros_transport = wifi_nina
+board_microros_user_meta = atomic.meta
 lib_deps =
-    arduino-libraries/WiFiNINA@^1.8.13
+    arduino-libraries/WiFiNINA
     ../
 
 ; Custom transports

--- a/extra_script.py
+++ b/extra_script.py
@@ -34,8 +34,8 @@ extra_packages_path = "{}/extra_packages".format(env['PROJECT_DIR'])
 
 selected_board_meta = boards_metas[board] if board in boards_metas else "colcon.meta"
 
-# Retrieve the required transport. Default iron
-microros_distro = global_env.BoardConfig().get("microros_distro", "iron")
+# Retrieve the required transport. Default kilted
+microros_distro = global_env.BoardConfig().get("microros_distro", "kilted")
 
 # Retrieve the required transport. Default serial
 microros_transport = global_env.BoardConfig().get("microros_transport", "serial")


### PR DESCRIPTION
As the develpment of pico/pico2 support on offical platformio had been
stalled for years, we have switched to platform/core contributed by
earlephilhower and maxgerhardt. It includes the latest toolchains gcc
14.3 and a lot of drivers/libraries.

The micro-ROS common meta defines "-DRCUTILS_NO_64_ATOMIC=ON", which
enables atomic ops functions in micro-ros/rcutils. But pico-sdk has
build-in atomic ops, so they conflict and result in link errors. An
user meta is added to avoid the errors.

The lib search is no longer needed.