### PR TITLE
Fix binutils path for Intel Macs

### DIFF
--- a/microros_utils/library_builder.py
+++ b/microros_utils/library_builder.py
@@ -1,4 +1,4 @@
-import os, sys
+import os, sys, platform
 import yaml
 import shutil
 
@@ -225,13 +225,24 @@ class Build:
                 shutil.rmtree(repeated_path)
 
     def resolve_binutils_path(self):
+        homebrew_binutils_path = None
+
         if sys.platform == "darwin":
-            homebrew_binutils_path = "/opt/homebrew/opt/binutils/bin/"
+            proc = platform.processor()
+            if proc == "arm":
+                # Apple Silicon path
+                homebrew_binutils_path = "/opt/homebrew/opt/binutils/bin/"
+            elif proc == "i386":
+                # Intel Mac path
+                homebrew_binutils_path = "/usr/local/opt/binutils/bin/"
+            else:
+                print(f"ERROR: Unknown processor architecture '{proc}'.")
+                sys.exit(1)
+
             if os.path.exists(homebrew_binutils_path):
                 return homebrew_binutils_path
 
-            print("ERROR: GNU binutils not found. ({}) Please install binutils with homebrew: brew install binutils"
-                  .format(homebrew_binutils_path))
+            print(
+                f"ERROR: GNU binutils not found. Tried: {homebrew_binutils_path}. Please install binutils with homebrew: brew install binutils"
+            )
             sys.exit(1)
-
-        return ""


### PR DESCRIPTION
Homebrew installs binutils under '/opt/homebrew/opt/binutils/bin/' on Apple Silicon, which causes build failures on Intel Macs. This PR adds logic to detect the host architecture and adjust the binutils path accordingly.

Verified to enable successful builds on an Intel Mac.