### PR TITLE
Add Arduino Giga support / Fix Arduino giga_r1_m7 build error

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Supported boards are:
 | Board                                        | Platform      | Framework   | Transports                               | Default meta file        |
 | -------------------------------------------- | ------------- | ----------- | ---------------------------------------- | ------------------------ |
 | `portenta_h7_m7`                             | `ststm32`     | `arduino`   | `serial` <br/> `wifi`                    | `colcon.meta`            |
+| `giga_r1_m7`                                 | `ststm32`     | `arduino`   | `serial` <br/> `wifi`                    | `colcon.meta`            |
 | `teensy41`                                   | `teensy`      | `arduino`   | `serial` <br/> `native_ethernet`         | `colcon.meta`            |
 | `teensy40`                                   | `teensy`      | `arduino`   | `serial`                                 | `colcon.meta`            |
 | `teensy36` <br/> `teensy35` <br/> `teensy31` | `teensy`      | `arduino`   | `serial`                                 | `colcon_lowmem.meta`     |

--- a/extra_script.py
+++ b/extra_script.py
@@ -117,7 +117,7 @@ def build_microros(*args, **kwargs):
     #######################################################
 
     # Add library
-    if (board == "portenta_h7_m7" or board == "nanorp2040connect" or board == "pico"):
+    if (board == "portenta_h7_m7" or board == "giga_r1_m7" or board == "nanorp2040connect" or board == "pico"):
         # Workaround for including the library in the linker group
         #   This solves a problem with duplicated symbols in Galactic
         global_env["_LIBFLAGS"] = "-Wl,--start-group " + global_env["_LIBFLAGS"] + " -l{} -Wl,--end-group".format(builder.library_name)


### PR DESCRIPTION
This small change fixes a linker error when building on the Arduino Giga board. Since everthing seems to function correctly I added it to the supported boards table. Feel free to remove the entry if it turns out to not be.

This was the error it fixes:
```
... lots of other random symbols ...
.pio/libdeps/serial/micro_ros_platformio/libmicroros/libmicroros.a(libtest_msgs__rosidl_typesupport_microxrcedds_c__unbounded_sequences__type_support_c.c.obj): In function `_UnboundedSequences__cdr_deserialize':
unbounded_sequences__type_support_c.c:(.text._UnboundedSequences__cdr_deserialize+0x1f2): undefined reference to `rosidl_typesupport_microxrcedds_c__get_message_type_support_handle__test_msgs__msg__BasicTypes'
.pio/libdeps/serial/micro_ros_platformio/libmicroros/libmicroros.a(libtest_msgs__rosidl_typesupport_microxrcedds_c__unbounded_sequences__type_support_c.c.obj): In function `_UnboundedSequences__cdr_serialize':
unbounded_sequences__type_support_c.c:(.text._UnboundedSequences__cdr_serialize+0x110): undefined reference to `rosidl_typesupport_microxrcedds_c__get_message_type_support_handle__test_msgs__msg__BasicTypes'
collect2: error: ld returned 1 exit status
*** [.pio/build/serial/firmware.elf] Error 1
```